### PR TITLE
Fix for Trigger collider position error

### DIFF
--- a/Assets/Devion Games/Triggers/Scripts/Runtime/BaseTrigger.cs
+++ b/Assets/Devion Games/Triggers/Scripts/Runtime/BaseTrigger.cs
@@ -308,12 +308,12 @@ namespace DevionGames
             handlerGameObject.transform.SetParent(transform,false);
             handlerGameObject.layer = 2;
 
-            Collider collider = GetComponent<Collider>();
-            if (collider != null)
+            MeshFilter meshFilter = null;
+            if (TryGetComponent<MeshFilter>(out meshFilter))
             {
-                position = collider.bounds.center;
-                position.y = (collider.bounds.center - collider.bounds.extents).y;
-                position = transform.InverseTransformPoint(position);
+                Bounds bounds = meshFilter.mesh.bounds;
+                position = bounds.center;
+                position.y = (bounds.center - bounds.extents).y;
             }
 
             SphereCollider sphereCollider = handlerGameObject.AddComponent<SphereCollider>();


### PR DESCRIPTION
When using pooled objects I have found the collider.bounds wrongly returning a local position, it should always return world position. I have found a couple of Unity bug reports about this, but no sign of a bug fix.
A workaround is to use the Mesh.bounds which always return local position.

I think this is an improvement because;
- It fixes my issue.
- It fixes the issue caused by the trigger collider being created centred around the bottom of the object collider. For example a 1 unit sphere on the ground, with a 2 unit radius collider. A 2 unit trigger collider would be created centred at y=-2, which means the whole trigger collider is below ground.
-For objects that do not have a collider, the trigger collider is below the centre of the mesh, not the object position. For long meshes, this is better as the collider will be in the middle instead of possibley one end.