### PR TITLE
Custom provider

### DIFF
--- a/Assets/Devion Games/Inventory System/Scripts/Runtime/InventoryManager.cs
+++ b/Assets/Devion Games/Inventory System/Scripts/Runtime/InventoryManager.cs
@@ -356,7 +356,7 @@ namespace DevionGames.InventorySystem
         }
 
         public static bool HasSavedData() {
-            string key = m_SaveProvider.GetString(InventoryManager.SavingLoading.savingKey, InventoryManager.SavingLoading.savingKey);
+            string key = PlayerPrefs.GetString(InventoryManager.SavingLoading.savingKey, InventoryManager.SavingLoading.savingKey);
             return InventoryManager.HasSavedData(key);
         }
 

--- a/Assets/Devion Games/Inventory System/Scripts/Runtime/InventoryManager.cs
+++ b/Assets/Devion Games/Inventory System/Scripts/Runtime/InventoryManager.cs
@@ -260,7 +260,7 @@ namespace DevionGames.InventorySystem
         }
 
         public static void Save() {
-            string key = m_SaveProvider.GetString(InventoryManager.SavingLoading.savingKey, InventoryManager.SavingLoading.savingKey);
+            string key = PlayerPrefs.GetString(InventoryManager.SavingLoading.savingKey, InventoryManager.SavingLoading.savingKey);
             Save(key);
         }
 
@@ -329,7 +329,7 @@ namespace DevionGames.InventorySystem
         }
 
         public static void Load() {
-            string key = m_SaveProvider.GetString(InventoryManager.SavingLoading.savingKey, InventoryManager.SavingLoading.savingKey);
+            string key = PlayerPrefs.GetString(InventoryManager.SavingLoading.savingKey, InventoryManager.SavingLoading.savingKey);
             Load(key);
         }
 

--- a/Assets/Devion Games/Inventory System/Scripts/Runtime/InventoryManager.cs
+++ b/Assets/Devion Games/Inventory System/Scripts/Runtime/InventoryManager.cs
@@ -188,7 +188,7 @@ namespace DevionGames.InventorySystem
 
                 if (!TryGetComponent<ISaveProvider>(out m_SaveProvider))
                 {
-                    m_SaveProvider = new ProviderPlayerPrefs();
+                    m_SaveProvider = gameObject.AddComponent<ProviderPlayerPrefs>();
                 } 
 
                 if (InventoryManager.SavingLoading.autoSave) {

--- a/Assets/Devion Games/Stat System/Scripts/Runtime/StatsManager.cs
+++ b/Assets/Devion Games/Stat System/Scripts/Runtime/StatsManager.cs
@@ -141,7 +141,7 @@ namespace DevionGames.StatSystem
 
                 if (!TryGetComponent<ISaveProvider>(out m_SaveProvider))
                 {
-                    m_SaveProvider = new ProviderPlayerPrefs();
+                    m_SaveProvider = gameObject.AddComponent<ProviderPlayerPrefs>();
                 }
 
                 if (StatsManager.SavingLoading.autoSave)

--- a/Assets/Devion Games/Stat System/Scripts/Runtime/StatsManager.cs
+++ b/Assets/Devion Games/Stat System/Scripts/Runtime/StatsManager.cs
@@ -164,7 +164,7 @@ namespace DevionGames.StatSystem
 
         public static void Save()
         {
-            string key = m_SaveProvider.GetString(StatsManager.SavingLoading.savingKey, StatsManager.SavingLoading.savingKey);
+            string key = PlayerPrefs.GetString(StatsManager.SavingLoading.savingKey, StatsManager.SavingLoading.savingKey);
             Save(key);
         }
 
@@ -207,7 +207,7 @@ namespace DevionGames.StatSystem
 
         public static void Load()
         {
-            string key = m_SaveProvider.GetString(StatsManager.SavingLoading.savingKey, StatsManager.SavingLoading.savingKey);
+            string key = PlayerPrefs.GetString(StatsManager.SavingLoading.savingKey, StatsManager.SavingLoading.savingKey);
             Load(key);
         }
 

--- a/Assets/Devion Games/Utilities/Scripts/Runtime/Interfaces/ISaveProvider.cs
+++ b/Assets/Devion Games/Utilities/Scripts/Runtime/Interfaces/ISaveProvider.cs
@@ -1,31 +1,31 @@
 
 public interface ISaveProvider
 {
-    public void DeleteKey(string key);
+    void DeleteKey(string key);
     /// <summary>
     /// Called after the last load operation.
     /// </summary>
-    public void EndLoad();
+    void EndLoad();
     /// <summary>
     /// Called after the last save operation.
     /// </summary>
-    public void EndSave();
-    public float GetFloat(string key);
-    public float GetFloat(string key, float defaultValue);
-    public int GetInt(string key);
-    public int GetInt(string key, int defaultValue);
-    public string GetString(string key);
-    public string GetString(string key, string defaultValue);
-    public bool HasKey(string key);
-    public void SetFloat(string key, float value);
-    public void SetInt(string key, int value);
-    public void SetString(string key, string value);
+    void EndSave();
+    float GetFloat(string key);
+    float GetFloat(string key, float defaultValue);
+    int GetInt(string key);
+    int GetInt(string key, int defaultValue);
+    string GetString(string key);
+    string GetString(string key, string defaultValue);
+    bool HasKey(string key);
+    void SetFloat(string key, float value);
+    void SetInt(string key, int value);
+    void SetString(string key, string value);
     /// <summary>
     /// Called before the first load operation.
     /// </summary>
-    public void StartLoad();
+    void StartLoad();
     /// <summary>
     /// Called before the first save operation.
     /// </summary>
-    public void StartSave();
+    void StartSave();
 }

--- a/Assets/Devion Games/Utilities/Scripts/Runtime/Interfaces/ISaveProvider.cs
+++ b/Assets/Devion Games/Utilities/Scripts/Runtime/Interfaces/ISaveProvider.cs
@@ -1,0 +1,31 @@
+
+public interface ISaveProvider
+{
+    public void DeleteKey(string key);
+    /// <summary>
+    /// Called after the last load operation.
+    /// </summary>
+    public void EndLoad();
+    /// <summary>
+    /// Called after the last save operation.
+    /// </summary>
+    public void EndSave();
+    public float GetFloat(string key);
+    public float GetFloat(string key, float defaultValue);
+    public int GetInt(string key);
+    public int GetInt(string key, int defaultValue);
+    public string GetString(string key);
+    public string GetString(string key, string defaultValue);
+    public bool HasKey(string key);
+    public void SetFloat(string key, float value);
+    public void SetInt(string key, int value);
+    public void SetString(string key, string value);
+    /// <summary>
+    /// Called before the first load operation.
+    /// </summary>
+    public void StartLoad();
+    /// <summary>
+    /// Called before the first save operation.
+    /// </summary>
+    public void StartSave();
+}

--- a/Assets/Devion Games/Utilities/Scripts/Runtime/Interfaces/ISaveProvider.cs.meta
+++ b/Assets/Devion Games/Utilities/Scripts/Runtime/Interfaces/ISaveProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 58cc4e6366ceaf342b9cba8f0ea5652d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Devion Games/Utilities/Scripts/Runtime/ProviderPlayerPrefs.cs
+++ b/Assets/Devion Games/Utilities/Scripts/Runtime/ProviderPlayerPrefs.cs
@@ -1,0 +1,78 @@
+using UnityEngine;
+
+/// <summary>
+/// Implements ISaveProvider for a PlayerPrefs backend.
+/// </summary>
+public class ProviderPlayerPrefs : MonoBehaviour, ISaveProvider
+{
+    public void DeleteKey(string key)
+    {
+        PlayerPrefs.DeleteKey(key);
+    }
+
+    public void EndLoad()
+    {
+    }
+
+    public void EndSave()
+    {
+    }
+
+    public float GetFloat(string key)
+    {
+        return PlayerPrefs.GetFloat(key);
+    }
+
+    public float GetFloat(string key, float defaultValue)
+    {
+        return PlayerPrefs.GetFloat(key,defaultValue);
+    }
+
+    public int GetInt(string key)
+    {
+        return PlayerPrefs.GetInt(key);
+    }
+
+    public int GetInt(string key, int defaultValue)
+    {
+        return PlayerPrefs.GetInt(key, defaultValue);
+    }
+
+    public string GetString(string key)
+    {
+        return PlayerPrefs.GetString(key);
+    }
+
+    public string GetString(string key, string defaultValue)
+    {
+        return PlayerPrefs.GetString(key, defaultValue);
+    }
+
+    public bool HasKey(string key)
+    {
+        return PlayerPrefs.HasKey(key);
+    }
+
+    public void SetFloat(string key, float value)
+    {
+        PlayerPrefs.SetFloat(key, value);
+    }
+
+    public void SetInt(string key, int value)
+    {
+        PlayerPrefs.SetInt(key, value);
+    }
+
+    public void SetString(string key, string value)
+    {
+        PlayerPrefs.SetString(key, value);
+    }
+
+    public void StartLoad()
+    {
+    }
+
+    public void StartSave()
+    {
+    }
+}

--- a/Assets/Devion Games/Utilities/Scripts/Runtime/ProviderPlayerPrefs.cs.meta
+++ b/Assets/Devion Games/Utilities/Scripts/Runtime/ProviderPlayerPrefs.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dbb1d60270d910149b761e0ca97a79c3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This is the minimal version of the custom provider for the InveventoryManager and StatsManager.
It should be backwardly compatible, i.e. it defaults to using ProviderPrefs.
If a component implementing ISaveProvider is added to the manager, it will be found and used instead of the default ProviderPrefs.
ProviderPlayerPrefs.cs is the ISaveProvider implementation for PlayerPrefs which is used by the default path. 
I have looked at the QuestManager and it is also compatible with this change and I will make the changes there too.