### PR TITLE
Updated Trigger Collider positioning

### DIFF
--- a/Assets/Devion Games/Triggers/Scripts/Editor/BaseTriggerInspector.cs
+++ b/Assets/Devion Games/Triggers/Scripts/Editor/BaseTriggerInspector.cs
@@ -15,6 +15,8 @@ namespace DevionGames
         private SerializedProperty m_TriggerInputType;
         private SerializedProperty m_TriggerKey;
         private AnimBool m_KeyOptions;
+        private SerializedProperty m_ManualColliderPosition;
+        private SerializedProperty m_ColliderOffset;
 
         protected override void OnEnable()
         {
@@ -27,6 +29,9 @@ namespace DevionGames
                 this.m_KeyOptions = new AnimBool((target as BaseTrigger).triggerType.HasFlag<BaseTrigger.TriggerInputType>(BaseTrigger.TriggerInputType.Key));
                 this.m_KeyOptions.valueChanged.AddListener(new UnityAction(Repaint));
             }
+            this.m_ColliderOffset = serializedObject.FindProperty("colliderOffset");
+            this.m_ManualColliderPosition = serializedObject.FindProperty("manualColliderPosition");
+
         }
 
         private void DrawInspector()
@@ -42,6 +47,12 @@ namespace DevionGames
                 EditorGUI.indentLevel = EditorGUI.indentLevel - 1;
             }
             EditorGUILayout.EndFadeGroup();
+
+            EditorGUILayout.PropertyField(this.m_ManualColliderPosition);
+            if (this.m_ManualColliderPosition.boolValue)
+            {
+                EditorGUILayout.PropertyField(this.m_ColliderOffset);
+            }
 
             if (EditorApplication.isPlaying) {
                 EditorGUI.BeginDisabledGroup(true);

--- a/Assets/Devion Games/Triggers/Scripts/Runtime/BaseTrigger.cs
+++ b/Assets/Devion Games/Triggers/Scripts/Runtime/BaseTrigger.cs
@@ -33,6 +33,11 @@ namespace DevionGames
         //If in range and trigger input type includes key, the key to use the trigger.
         public KeyCode key = KeyCode.F;
 
+        [Tooltip("Allow overriding the automatic positioning of the trigger collider")]
+        public bool manualColliderPosition;
+        [Tooltip("The trigger collider offset, this is before scaling and rotation of the parent object.")]
+        public Vector3 colliderOffset;
+ 
         //Custom Trigger callbacks
         protected ITriggerEventHandler[] m_TriggerEvents;
         //Current trigger used by the player
@@ -308,12 +313,20 @@ namespace DevionGames
             handlerGameObject.transform.SetParent(transform,false);
             handlerGameObject.layer = 2;
 
-            Collider collider = GetComponent<Collider>();
-            if (collider != null)
+            if (manualColliderPosition)
             {
-                position = collider.bounds.center;
-                position.y = (collider.bounds.center - collider.bounds.extents).y;
-                position = transform.InverseTransformPoint(position);
+                position = colliderOffset;
+            }
+            else
+            {
+                Renderer renderer = null;
+                if (TryGetComponent<Renderer>(out renderer))
+                {
+                    Bounds bounds = renderer.bounds;
+                    position = bounds.center;
+                    position.y = (bounds.center - bounds.extents).y;
+                    position = transform.InverseTransformPoint(position);
+                }
             }
 
             SphereCollider sphereCollider = handlerGameObject.AddComponent<SphereCollider>();


### PR DESCRIPTION
These are the latest fixes.
Changed from using mesh.bounds to renderer.bounds as the mesh.bounds are unreliable when multiple copies of static objects are in the scene. This is where the trigger collider appears at random locations.
Implemented a manual override for the automatic placement of the trigger collider. This is to fix issues where the object is angled and/or below ground level. i.e SpeedTrees trunks and roots.